### PR TITLE
Add op/extract/split Unit Test

### DIFF
--- a/tests/op/extract/split/test_markdown_header_splitter.py
+++ b/tests/op/extract/split/test_markdown_header_splitter.py
@@ -1,0 +1,52 @@
+import unittest
+
+from uniflow.node import Node
+from uniflow.op.extract.split.markdown_header_splitter import MarkdownHeaderSplitter
+
+
+class TestMarkdownHeaderSplitter(unittest.TestCase):
+    def setUp(self):
+        self.splitter = MarkdownHeaderSplitter("test_splitter")
+
+    def test_call(self):
+        node0 = Node(name="node1", value_dict={"text": "# Header ## Content"})
+        node1 = Node(name="node1", value_dict={"text": "# Header\n## Content"})
+
+        output_nodes = self.splitter([node0, node1])
+
+        self.assertEqual(len(output_nodes), 2)
+        self.assertEqual(output_nodes[0].value_dict["text"], ["# Header ## Content"])
+        self.assertEqual(output_nodes[1].value_dict["text"], ["# Header", "## Content"])
+
+    def test_header_splitter(self):
+        markdown_str0 = "# Header\n## Content"
+        markdown_str1 = "# Header\n## Content\n# Header 2 ## Content 2"
+
+        result0 = self.splitter.header_splitter(markdown_str0)
+        result1 = self.splitter.header_splitter(markdown_str1)
+
+        self.assertEqual(result0, ["# Header", "## Content"])
+        self.assertEqual(result1, ["# Header", "## Content", "# Header 2 ## Content 2"])
+
+    def test_header_splitter_with_custom_headers(self):
+        markdown_str = " <h1># Header</h1> \n Content"
+        headers_to_split_on_list0 = []
+        headers_to_split_on_list1 = [("\n", "h2")]
+        headers_to_split_on_list2 = [("<h1>", "h1")]
+
+        result = self.splitter.header_splitter(markdown_str, None)
+        result0 = self.splitter.header_splitter(markdown_str, headers_to_split_on_list0)
+        result1 = self.splitter.header_splitter(markdown_str, headers_to_split_on_list1)
+        result2 = self.splitter.header_splitter(markdown_str, headers_to_split_on_list2)
+
+        self.assertEqual(result, ['<h1># Header</h1>\nContent'])  
+        self.assertEqual(result0, [])  
+        self.assertEqual(result1, [])  
+        # self.assertEqual(result2, ['<h1># Header</h1>\nContent'])  
+
+    def test_header_splitter_with_no_headers(self):
+        markdown_str = "\nContent with no headers"
+
+        result = self.splitter.header_splitter(markdown_str)
+
+        self.assertEqual(result, ['Content with no headers'])  # No split should occur

--- a/tests/op/extract/split/test_markdown_header_splitter.py
+++ b/tests/op/extract/split/test_markdown_header_splitter.py
@@ -48,14 +48,6 @@ class TestMarkdownHeaderSplitter(unittest.TestCase):
 
         self.assertEqual(result, [])
 
-    def test_header_splitter_with_htmlstyle_custom_headers(self):
-        markdown_str = " <h1># Header</h1> \n Content"
-        custom_header = [("<h1>", "h1")]
-
-        result = self.splitter.header_splitter(markdown_str, custom_header)
-
-        self.assertEqual(result, ["<h1># Header</h1>\nContent"])
-
     def test_header_splitter_with_no_headers(self):
         markdown_str = "\nContent with no headers"
 

--- a/tests/op/extract/split/test_markdown_header_splitter.py
+++ b/tests/op/extract/split/test_markdown_header_splitter.py
@@ -8,7 +8,7 @@ class TestMarkdownHeaderSplitter(unittest.TestCase):
     def setUp(self):
         self.splitter = MarkdownHeaderSplitter("test_splitter")
 
-    def test_call(self):
+    def test_special_function_call(self):
         node0 = Node(name="node1", value_dict={"text": "# Header ## Content"})
         node1 = Node(name="node1", value_dict={"text": "# Header\n## Content"})
 
@@ -18,35 +18,47 @@ class TestMarkdownHeaderSplitter(unittest.TestCase):
         self.assertEqual(output_nodes[0].value_dict["text"], ["# Header ## Content"])
         self.assertEqual(output_nodes[1].value_dict["text"], ["# Header", "## Content"])
 
-    def test_header_splitter(self):
-        markdown_str0 = "# Header\n## Content"
-        markdown_str1 = "# Header\n## Content\n# Header 2 ## Content 2"
+    def test_header_splitter_basic(self):
+        markdown_str = "# Header\n## Content"
 
-        result0 = self.splitter.header_splitter(markdown_str0)
-        result1 = self.splitter.header_splitter(markdown_str1)
+        result = self.splitter.header_splitter(markdown_str)
 
-        self.assertEqual(result0, ["# Header", "## Content"])
-        self.assertEqual(result1, ["# Header", "## Content", "# Header 2 ## Content 2"])
+        self.assertEqual(result, ["# Header", "## Content"])
 
-    def test_header_splitter_with_custom_headers(self):
+    def test_header_splitter_multilevel_header(self):
+        markdown_str = "# Header\n## Content\n# Header 2 ## Content 2"
+
+        result = self.splitter.header_splitter(markdown_str)
+
+        self.assertEqual(result, ["# Header", "## Content", "# Header 2 ## Content 2"])
+
+    def test_header_splitter_with_empty_custom_headers(self):
+        markdown_str = "# Header \n Content"
+        custom_header = []
+
+        result = self.splitter.header_splitter(markdown_str, custom_header)
+
+        self.assertEqual(result, [])
+
+    def test_header_splitter_with_invalid_custom_headers(self):
+        markdown_str = "# Header</h1> \n Content"
+        custom_header = [("\n", "h2")]
+
+        result = self.splitter.header_splitter(markdown_str, custom_header)
+
+        self.assertEqual(result, [])
+
+    def test_header_splitter_with_htmlstyle_custom_headers(self):
         markdown_str = " <h1># Header</h1> \n Content"
-        headers_to_split_on_list0 = []
-        headers_to_split_on_list1 = [("\n", "h2")]
-        headers_to_split_on_list2 = [("<h1>", "h1")]
+        custom_header = [("<h1>", "h1")]
 
-        result = self.splitter.header_splitter(markdown_str, None)
-        result0 = self.splitter.header_splitter(markdown_str, headers_to_split_on_list0)
-        result1 = self.splitter.header_splitter(markdown_str, headers_to_split_on_list1)
-        result2 = self.splitter.header_splitter(markdown_str, headers_to_split_on_list2)
+        result = self.splitter.header_splitter(markdown_str, custom_header)
 
-        self.assertEqual(result, ['<h1># Header</h1>\nContent'])  
-        self.assertEqual(result0, [])  
-        self.assertEqual(result1, [])  
-        # self.assertEqual(result2, ['<h1># Header</h1>\nContent'])  
+        self.assertEqual(result, ["<h1># Header</h1>\nContent"])
 
     def test_header_splitter_with_no_headers(self):
         markdown_str = "\nContent with no headers"
 
         result = self.splitter.header_splitter(markdown_str)
 
-        self.assertEqual(result, ['Content with no headers'])  # No split should occur
+        self.assertEqual(result, ["Content with no headers"])  # No split should occur

--- a/tests/op/extract/split/test_pattern_splitter_op.py
+++ b/tests/op/extract/split/test_pattern_splitter_op.py
@@ -1,0 +1,33 @@
+import unittest
+from uniflow.node import Node
+from uniflow.op.extract.split.pattern_splitter_op import PatternSplitter
+
+
+class TestPatternSplitter(unittest.TestCase):
+    def setUp(self):
+        self.splitter = PatternSplitter("test_splitter")
+
+    def test_call(self):
+        node = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
+
+        output_nodes = self.splitter([node])
+
+        self.assertEqual(len(output_nodes), 1)
+        self.assertEqual(output_nodes[0].value_dict["text"], ["Hello", "World"])
+
+    def test_call_with_custom_splitter(self):
+        splitter = PatternSplitter("test_splitter", splitter=" ")
+        node = Node(name="node1", value_dict={"text": "Hello World"})
+
+        output_nodes = splitter([node])
+
+        self.assertEqual(len(output_nodes), 1)
+        self.assertEqual(output_nodes[0].value_dict["text"], ["Hello", "World"])
+
+    def test_call_with_no_split(self):
+        node = Node(name="node1", value_dict={"text": "HelloWorld"})
+
+        output_nodes = self.splitter([node])
+
+        self.assertEqual(len(output_nodes), 1)
+        self.assertEqual(output_nodes[0].value_dict["text"], ["HelloWorld"])

--- a/tests/op/extract/split/test_pattern_splitter_op.py
+++ b/tests/op/extract/split/test_pattern_splitter_op.py
@@ -1,4 +1,5 @@
 import unittest
+
 from uniflow.node import Node
 from uniflow.op.extract.split.pattern_splitter_op import PatternSplitter
 
@@ -7,7 +8,7 @@ class TestPatternSplitter(unittest.TestCase):
     def setUp(self):
         self.splitter = PatternSplitter("test_splitter")
 
-    def test_call(self):
+    def test_special_function_call(self):
         node = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
 
         output_nodes = self.splitter([node])
@@ -15,7 +16,7 @@ class TestPatternSplitter(unittest.TestCase):
         self.assertEqual(len(output_nodes), 1)
         self.assertEqual(output_nodes[0].value_dict["text"], ["Hello", "World"])
 
-    def test_call_with_custom_splitter(self):
+    def test_special_function_call_with_custom_splitter(self):
         splitter = PatternSplitter("test_splitter", splitter=" ")
         node = Node(name="node1", value_dict={"text": "Hello World"})
 
@@ -24,7 +25,7 @@ class TestPatternSplitter(unittest.TestCase):
         self.assertEqual(len(output_nodes), 1)
         self.assertEqual(output_nodes[0].value_dict["text"], ["Hello", "World"])
 
-    def test_call_with_no_split(self):
+    def test_special_function_call_with_no_split(self):
         node = Node(name="node1", value_dict={"text": "HelloWorld"})
 
         output_nodes = self.splitter([node])

--- a/tests/op/extract/split/test_recursive_character_splitter.py
+++ b/tests/op/extract/split/test_recursive_character_splitter.py
@@ -26,17 +26,23 @@ class TestRecursiveCharacterSplitter(unittest.TestCase):
 
         self.assertEqual(chunks, ["HelloWorld"])
 
-    def test_recursive_splitter_with_small_chunk(self):
-        splitter0 = RecursiveCharacterSplitter("test_splitter", chunk_size=0)
-        splitter1 = RecursiveCharacterSplitter("test_splitter", chunk_size=1)
+    def test_recursive_splitter_with_small_chunk_size(self):
+        splitter = RecursiveCharacterSplitter("test_splitter", chunk_size=1)
         text = "Hello\n\nWorld"
         expected_chunks = ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"]
 
-        chunks0 = splitter0._recursive_splitter(text, self.default_separators)
-        chunks1 = splitter1._recursive_splitter(text, self.default_separators)
+        chunks = splitter._recursive_splitter(text, self.default_separators)
 
-        self.assertEqual(chunks0, expected_chunks)
-        self.assertEqual(chunks1, expected_chunks)
+        self.assertEqual(chunks, expected_chunks)
+
+    def test_recursive_splitter_with_zero_chunk_size(self):
+        splitter = RecursiveCharacterSplitter("test_splitter", chunk_size=0)
+        text = "Hello\n\nWorld"
+        expected_chunks = ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"]
+
+        chunks = splitter._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(chunks, expected_chunks)
 
     def test_recursive_splitter_with_no_separators(self):
         text = "Hello\n\nWorld"
@@ -61,28 +67,30 @@ class TestRecursiveCharacterSplitter(unittest.TestCase):
 
         self.assertEqual(chunks, ["Hello", "World."])
 
-    def test_recursive_splitter_with_large_text(self):
-        splitter0 = RecursiveCharacterSplitter("test_splitter", chunk_size=1)
-        splitter1 = RecursiveCharacterSplitter("test_splitter", chunk_size=9999)
+    def test_recursive_splitter_with_large_text_default_chunk(self):
         text = "Hello\n\nWorld\n\n" * 100
 
         chunks = self.splitter._recursive_splitter(text, self.default_separators)
-        chunks0 = splitter0._recursive_splitter(text, self.default_separators)
-        chunks1 = splitter1._recursive_splitter(text, self.default_separators)
 
         self.assertEqual(len(chunks), 100)
-        self.assertEqual(len(chunks0), 10 * 100)
-        self.assertEqual(len(chunks1), 1)
-        self.assertEqual(chunks1, ['HelloWorld' * 100])
 
-    def test_call(self):
+    def test_recursive_splitter_with_large_text_large_chunk(self):
+        splitter = RecursiveCharacterSplitter("test_splitter", chunk_size=9999)
+        text = "Hello\n\nWorld\n\n" * 100
+
+        chunks = splitter._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks, ["HelloWorld" * 100])
+
+    def test_special_function_call(self):
         node = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
         output_nodes = self.splitter([node])
 
         self.assertEqual(len(output_nodes), 1)
         self.assertEqual(output_nodes[0].value_dict["text"], ["HelloWorld"])
 
-    def test_call_with_multiple_nodes(self):
+    def test_special_function_call_with_multiple_nodes(self):
         node0 = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
         expected0 = ["HelloWorld"]
         node1 = Node(name="node1", value_dict={"text": "Hello\n\nWorld."})

--- a/tests/op/extract/split/test_recursive_character_splitter.py
+++ b/tests/op/extract/split/test_recursive_character_splitter.py
@@ -1,0 +1,101 @@
+import unittest
+
+from uniflow.node import Node
+from uniflow.op.extract.split.recursive_character_splitter import (
+    RecursiveCharacterSplitter,
+)
+
+
+class TestRecursiveCharacterSplitter(unittest.TestCase):
+    def setUp(self):
+        self.splitter = RecursiveCharacterSplitter("test_splitter", chunk_size=10)
+        self.default_separators = ["\n\n", "\n", " ", ""]
+
+    def test_recursive_splitter(self):
+        text = "Hello\n\nWorld."
+
+        chunks = self.splitter._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(chunks, ["Hello", "World."])
+
+    def test_recursive_splitter_with_merge_chunk(self):
+        splitter = RecursiveCharacterSplitter("test_splitter", chunk_size=100)
+        text = "Hello\n\nWorld"
+
+        chunks = splitter._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(chunks, ["HelloWorld"])
+
+    def test_recursive_splitter_with_small_chunk(self):
+        splitter0 = RecursiveCharacterSplitter("test_splitter", chunk_size=0)
+        splitter1 = RecursiveCharacterSplitter("test_splitter", chunk_size=1)
+        text = "Hello\n\nWorld"
+        expected_chunks = ["H", "e", "l", "l", "o", "W", "o", "r", "l", "d"]
+
+        chunks0 = splitter0._recursive_splitter(text, self.default_separators)
+        chunks1 = splitter1._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(chunks0, expected_chunks)
+        self.assertEqual(chunks1, expected_chunks)
+
+    def test_recursive_splitter_with_no_separators(self):
+        text = "Hello\n\nWorld"
+        separators = []
+
+        chunks = self.splitter._recursive_splitter(text, separators)
+
+        self.assertEqual(chunks, [])
+
+    def test_recursive_splitter_with_no_split(self):
+        text = "HelloWorld"
+
+        chunks = self.splitter._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(chunks, ["HelloWorld"])
+
+    def test_recursive_splitter_with_custom_separators(self):
+        text = "Hello--World."
+        separators = ["-", " "]
+
+        chunks = self.splitter._recursive_splitter(text, separators)
+
+        self.assertEqual(chunks, ["Hello", "World."])
+
+    def test_recursive_splitter_with_large_text(self):
+        splitter0 = RecursiveCharacterSplitter("test_splitter", chunk_size=1)
+        splitter1 = RecursiveCharacterSplitter("test_splitter", chunk_size=9999)
+        text = "Hello\n\nWorld\n\n" * 100
+
+        chunks = self.splitter._recursive_splitter(text, self.default_separators)
+        chunks0 = splitter0._recursive_splitter(text, self.default_separators)
+        chunks1 = splitter1._recursive_splitter(text, self.default_separators)
+
+        self.assertEqual(len(chunks), 100)
+        self.assertEqual(len(chunks0), 10 * 100)
+        self.assertEqual(len(chunks1), 1)
+        self.assertEqual(chunks1, ['HelloWorld' * 100])
+
+    def test_call(self):
+        node = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
+        output_nodes = self.splitter([node])
+
+        self.assertEqual(len(output_nodes), 1)
+        self.assertEqual(output_nodes[0].value_dict["text"], ["HelloWorld"])
+
+    def test_call_with_multiple_nodes(self):
+        node0 = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
+        expected0 = ["HelloWorld"]
+        node1 = Node(name="node1", value_dict={"text": "Hello\n\nWorld."})
+        expected1 = ["Hello", "World."]
+        node2 = Node(name="node1", value_dict={"text": "Hello\n\nWorld\n\n" * 10})
+        expected2 = ["HelloWorld"] * 10
+        node3 = Node(name="node1", value_dict={"text": "Hello\n\nWorld.\n\n" * 2})
+        expected3 = ["Hello", "World.", "Hello", "World."]
+
+        output_nodes = self.splitter([node0, node1, node2, node3])
+
+        self.assertEqual(len(output_nodes), 4)
+        self.assertEqual(output_nodes[0].value_dict["text"], expected0)
+        self.assertEqual(output_nodes[1].value_dict["text"], expected1)
+        self.assertEqual(output_nodes[2].value_dict["text"], expected2)
+        self.assertEqual(output_nodes[3].value_dict["text"], expected3)

--- a/tests/op/extract/split/test_recursive_character_splitter.py
+++ b/tests/op/extract/split/test_recursive_character_splitter.py
@@ -92,18 +92,17 @@ class TestRecursiveCharacterSplitter(unittest.TestCase):
 
     def test_special_function_call_with_multiple_nodes(self):
         node0 = Node(name="node1", value_dict={"text": "Hello\n\nWorld"})
-        expected0 = ["HelloWorld"]
         node1 = Node(name="node1", value_dict={"text": "Hello\n\nWorld."})
-        expected1 = ["Hello", "World."]
         node2 = Node(name="node1", value_dict={"text": "Hello\n\nWorld\n\n" * 10})
-        expected2 = ["HelloWorld"] * 10
         node3 = Node(name="node1", value_dict={"text": "Hello\n\nWorld.\n\n" * 2})
-        expected3 = ["Hello", "World.", "Hello", "World."]
+        expected_texts = [
+            ["HelloWorld"],
+            ["Hello", "World."],
+            ["HelloWorld"] * 10,
+            ["Hello", "World.", "Hello", "World."],
+        ]
 
         output_nodes = self.splitter([node0, node1, node2, node3])
+        output_texts = [node.value_dict["text"] for node in output_nodes]
 
-        self.assertEqual(len(output_nodes), 4)
-        self.assertEqual(output_nodes[0].value_dict["text"], expected0)
-        self.assertEqual(output_nodes[1].value_dict["text"], expected1)
-        self.assertEqual(output_nodes[2].value_dict["text"], expected2)
-        self.assertEqual(output_nodes[3].value_dict["text"], expected3)
+        self.assertEqual(output_texts, expected_texts)

--- a/tests/op/extract/split/test_splitter_factory.py
+++ b/tests/op/extract/split/test_splitter_factory.py
@@ -35,9 +35,10 @@ class TestSplitterOpsFactory(unittest.TestCase):
             SplitterOpsFactory.get("")
 
     def test_list(self):
-        splitters = SplitterOpsFactory.list()
+        excepted_splitters = [
+            PARAGRAPH_SPLITTER,
+            MARKDOWN_HEADER_SPLITTER,
+            RECURSIVE_CHARACTER_SPLITTER,
+        ]
 
-        self.assertEqual(len(splitters), 3)
-        self.assertIn(PARAGRAPH_SPLITTER, splitters)
-        self.assertIn(MARKDOWN_HEADER_SPLITTER, splitters)
-        self.assertIn(RECURSIVE_CHARACTER_SPLITTER, splitters)
+        self.assertEqual(SplitterOpsFactory.list(), excepted_splitters)

--- a/tests/op/extract/split/test_splitter_factory.py
+++ b/tests/op/extract/split/test_splitter_factory.py
@@ -1,0 +1,43 @@
+import unittest
+
+from uniflow.op.extract.split.constants import (
+    MARKDOWN_HEADER_SPLITTER,
+    PARAGRAPH_SPLITTER,
+    RECURSIVE_CHARACTER_SPLITTER,
+)
+from uniflow.op.extract.split.markdown_header_splitter import MarkdownHeaderSplitter
+from uniflow.op.extract.split.pattern_splitter_op import PatternSplitter
+from uniflow.op.extract.split.recursive_character_splitter import (
+    RecursiveCharacterSplitter,
+)
+from uniflow.op.extract.split.splitter_factory import SplitterOpsFactory
+
+
+class TestSplitterOpsFactory(unittest.TestCase):
+    def setUp(self):
+        self.paragraph_splitter = SplitterOpsFactory.get(PARAGRAPH_SPLITTER)
+        self.markdown_header_splitter = SplitterOpsFactory.get(MARKDOWN_HEADER_SPLITTER)
+        self.recursive_character_splitter = SplitterOpsFactory.get(
+            RECURSIVE_CHARACTER_SPLITTER
+        )
+
+    def test_get(self):
+        self.assertTrue(isinstance(self.paragraph_splitter, PatternSplitter))
+        self.assertTrue(
+            isinstance(self.markdown_header_splitter, MarkdownHeaderSplitter)
+        )
+        self.assertTrue(
+            isinstance(self.recursive_character_splitter, RecursiveCharacterSplitter)
+        )
+
+    def test_get_with_invalid_name(self):
+        with self.assertRaises(ValueError):
+            SplitterOpsFactory.get("")
+
+    def test_list(self):
+        splitters = SplitterOpsFactory.list()
+
+        self.assertEqual(len(splitters), 3)
+        self.assertIn(PARAGRAPH_SPLITTER, splitters)
+        self.assertIn(MARKDOWN_HEADER_SPLITTER, splitters)
+        self.assertIn(RECURSIVE_CHARACTER_SPLITTER, splitters)


### PR DESCRIPTION
Add the following tests:
- test_markdown_header_splitter
  - cannot pass custom headers, e.g. `<h1> xx </h1>`
- test_recursive_character_splitter
- test_pattern_splitter_op
- test_splitter_factory