### PR TITLE
Refinement: setting batch_size for different models

### DIFF
--- a/uniflow/flow/server.py
+++ b/uniflow/flow/server.py
@@ -200,6 +200,11 @@ class TransformServer:
         batch_size = self._config.model_config.get(
             "batch_size", 1
         )  # pylint: disable=no-member
+        if not batch_size:
+            batch_size = self._config.model_config.get(
+            "num_thread", 1
+        )  # pylint: disable=no-member
+
         if batch_size <= 0:
             raise ValueError("Batch size must be a positive integer.")
         if not input_list:  # Check if the list is empty

--- a/uniflow/flow/server.py
+++ b/uniflow/flow/server.py
@@ -196,7 +196,8 @@ class TransformServer:
             List[Mapping[str, Any]]: List of batches
         """
         # currently only HuggingFace model support batch.
-        # this will require some refactoring to support other models.
+        # For others, we use a thread pool to invoke remote server
+        # multiple times to mock a batch inference.
         batch_size = self._config.model_config.get("batch_size", None)
         if not batch_size:
             batch_size = self._config.model_config.get(

--- a/uniflow/flow/server.py
+++ b/uniflow/flow/server.py
@@ -198,8 +198,8 @@ class TransformServer:
         # currently only HuggingFace model support batch.
         # this will require some refactoring to support other models.
         batch_size = self._config.model_config.get(
-            "batch_size", 1
-        )  # pylint: disable=no-member
+            "batch_size", None
+        )
         if not batch_size:
             batch_size = self._config.model_config.get(
             "num_thread", 1

--- a/uniflow/flow/server.py
+++ b/uniflow/flow/server.py
@@ -197,9 +197,7 @@ class TransformServer:
         """
         # currently only HuggingFace model support batch.
         # this will require some refactoring to support other models.
-        batch_size = self._config.model_config.get(
-            "batch_size", None
-        )
+        batch_size = self._config.model_config.get("batch_size", None)
         if not batch_size:
             batch_size = self._config.model_config.get(
                 "num_thread", 1

--- a/uniflow/flow/server.py
+++ b/uniflow/flow/server.py
@@ -202,8 +202,8 @@ class TransformServer:
         )
         if not batch_size:
             batch_size = self._config.model_config.get(
-            "num_thread", 1
-        )  # pylint: disable=no-member
+                "num_thread", 1
+            )  # pylint: disable=no-member
 
         if batch_size <= 0:
             raise ValueError("Batch size must be a positive integer.")

--- a/uniflow/op/model/model_config.py
+++ b/uniflow/op/model/model_config.py
@@ -26,7 +26,7 @@ class GoogleModelConfig(ModelConfig):
     candidate_count: int = 1
     num_thread: int = 1
     # this is not real batch inference, but size to group for thread pool executor.
-    batch_size: int = 1
+    # batch_size: int = 1
 
 
 @dataclass
@@ -47,7 +47,7 @@ class OpenAIModelConfig(ModelConfig):
     response_format: Dict[str, str] = field(default_factory=lambda: {"type": "text"})
     num_thread: int = 1
     # this is not real batch inference, but size to group for thread pool executor.
-    batch_size: int = 1
+    # batch_size: int = 1
 
 
 @dataclass
@@ -64,7 +64,7 @@ class AzureOpenAIModelConfig:
     response_format: Dict[str, str] = field(default_factory=lambda: {"type": "text"})
     num_thread: int = 1
     # this is not real batch inference, but size to group for thread pool executor.
-    batch_size: int = 1
+    # batch_size: int = 1
 
 
 @dataclass

--- a/uniflow/op/model/model_config.py
+++ b/uniflow/op/model/model_config.py
@@ -25,8 +25,6 @@ class GoogleModelConfig(ModelConfig):
     top_p: float = 1.0
     candidate_count: int = 1
     num_thread: int = 1
-    # this is not real batch inference, but size to group for thread pool executor.
-    # batch_size: int = 1
 
 
 @dataclass
@@ -46,8 +44,6 @@ class OpenAIModelConfig(ModelConfig):
     temperature: float = 0.9
     response_format: Dict[str, str] = field(default_factory=lambda: {"type": "text"})
     num_thread: int = 1
-    # this is not real batch inference, but size to group for thread pool executor.
-    # batch_size: int = 1
 
 
 @dataclass
@@ -63,8 +59,6 @@ class AzureOpenAIModelConfig:
     temperature: float = 0.7
     response_format: Dict[str, str] = field(default_factory=lambda: {"type": "text"})
     num_thread: int = 1
-    # this is not real batch inference, but size to group for thread pool executor.
-    # batch_size: int = 1
 
 
 @dataclass


### PR DESCRIPTION
Since [Google's model](https://github.com/CambioML/uniflow-llm-based-pdf-extraction-text-cleaning-data-clustering/blob/a58216cc85bd673b8a73c68ea9c82fcad45a4f5d/uniflow/op/model/model_config.py#L17), [OpenAI's model](https://github.com/CambioML/uniflow-llm-based-pdf-extraction-text-cleaning-data-clustering/blob/a58216cc85bd673b8a73c68ea9c82fcad45a4f5d/uniflow/op/model/model_config.py#L41), and [Azure OpenAI's model](https://github.com/CambioML/uniflow-llm-based-pdf-extraction-text-cleaning-data-clustering/blob/a58216cc85bd673b8a73c68ea9c82fcad45a4f5d/uniflow/op/model/model_config.py#L54) don't support batching locally, we will instead use `num_thread` to "fake batch" the data.